### PR TITLE
Add stacked yearly chart

### DIFF
--- a/pfc_app/templates/pfc_app/dashboard.html
+++ b/pfc_app/templates/pfc_app/dashboard.html
@@ -38,6 +38,11 @@
             <canvas id="inscricoesPorMesChart"></canvas>
         </div>
     </div>
+    <div class="row mt-5">
+        <div class="col-md-12">
+            <canvas id="cursosInscricoesPorAnoChart"></canvas>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -45,6 +50,9 @@
     const meses = {{ meses|safe }};
     const cursosPorMes = {{ cursos_por_mes|safe }};
     const inscricoesPorMes = {{ inscricoes_por_mes|safe }};
+    const anos = {{ anos|safe }};
+    const cursosPorAno = {{ cursos_por_ano|safe }};
+    const inscricoesPorAno = {{ inscricoes_por_ano|safe }};
 
     new Chart(
         document.getElementById('cursosPorMesChart').getContext('2d'),
@@ -81,6 +89,34 @@
             options: {
                 scales: {
                     y: { beginAtZero: true }
+                }
+            }
+        }
+    );
+
+    new Chart(
+        document.getElementById('cursosInscricoesPorAnoChart').getContext('2d'),
+        {
+            type: 'bar',
+            data: {
+                labels: anos,
+                datasets: [
+                    {
+                        label: 'Cursos',
+                        data: cursosPorAno,
+                        backgroundColor: 'rgba(54, 162, 235, 0.6)'
+                    },
+                    {
+                        label: 'Inscrições',
+                        data: inscricoesPorAno,
+                        backgroundColor: 'rgba(255, 99, 132, 0.6)'
+                    }
+                ]
+            },
+            options: {
+                scales: {
+                    x: { stacked: true },
+                    y: { beginAtZero: true, stacked: true }
                 }
             }
         }

--- a/pfc_app/views.py
+++ b/pfc_app/views.py
@@ -120,6 +120,26 @@ def dashboard(request):
 
     meses = [name for _, name in MONTHS]
 
+    cursos_por_ano_qs = (
+        Curso.objects
+        .annotate(a=ExtractYear('data_inicio'))
+        .values('a')
+        .annotate(c=Count('id'))
+        .order_by('a')
+    )
+    inscricoes_por_ano_qs = (
+        Inscricao.objects
+        .annotate(a=ExtractYear('curso__data_inicio'))
+        .values('a')
+        .annotate(c=Count('id'))
+        .order_by('a')
+    )
+    cursos_por_ano_dict = {item['a']: item['c'] for item in cursos_por_ano_qs}
+    inscricoes_por_ano_dict = {item['a']: item['c'] for item in inscricoes_por_ano_qs}
+    anos = sorted(set(cursos_por_ano_dict) | set(inscricoes_por_ano_dict))
+    cursos_por_ano = [cursos_por_ano_dict.get(ano, 0) for ano in anos]
+    inscricoes_por_ano = [inscricoes_por_ano_dict.get(ano, 0) for ano in anos]
+
     context = {
         'total_cursos': total_cursos,
         'total_inscricoes': total_inscricoes,
@@ -127,6 +147,9 @@ def dashboard(request):
         'meses': json.dumps(meses),
         'cursos_por_mes': json.dumps(cursos_por_mes),
         'inscricoes_por_mes': json.dumps(inscricoes_por_mes),
+        'anos': json.dumps(anos),
+        'cursos_por_ano': json.dumps(cursos_por_ano),
+        'inscricoes_por_ano': json.dumps(inscricoes_por_ano),
     }
     return render(request, 'pfc_app/dashboard.html', context)
 


### PR DESCRIPTION
## Summary
- gather yearly course and enrollment counts
- show stacked bar chart with those counts in dashboard

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685dea21b0ec8327ba235dca76015873